### PR TITLE
Finishing settings menu (except for mouse sens)

### DIFF
--- a/game/Loader/save.gd
+++ b/game/Loader/save.gd
@@ -43,6 +43,7 @@ func load_data():
 			"vsync_on": false,
 			"display_fps": false,
 			"max_fps": 0,
+			"bloom_on": false,
 			"brightness": 1,
 			"master_vol": -10,
 			"music_vol": -10,

--- a/game/Scenes/SettingsMenu/settingsMenu.gd
+++ b/game/Scenes/SettingsMenu/settingsMenu.gd
@@ -11,12 +11,18 @@
 
 extends Popup
 
+# Member Variables
+var MASTER_VOLUME = 0 #corresponds to master volume bus
+var MUSIC_VOLUME = 1 #corresponds to music volume bus
+var SFX_VOLUME = 2 #corrsponds to sfx volume bus
+
 # Video Settings
 onready var displayOptions = $SettingsTabs/Video/MarginContainer/videoSettings/DisplayOptionsButton
 onready var vsyncButton = $SettingsTabs/Video/MarginContainer/videoSettings/VsyncButton
 onready var displayFpsButton = $SettingsTabs/Video/MarginContainer/videoSettings/DisplayFpsButton
 onready var maxFpsVal = $SettingsTabs/Video/MarginContainer/videoSettings/FpsSlider/MaxFpsVal
 onready var maxFpsSlider = $SettingsTabs/Video/MarginContainer/videoSettings/FpsSlider/MaxFpsSlider
+onready var bloomButton = $SettingsTabs/Video/MarginContainer/videoSettings/BloomButton
 onready var brightnessSlider = $SettingsTabs/Video/MarginContainer/videoSettings/Brightness/BrightnessSlider
 
 # Audio Settings
@@ -46,10 +52,14 @@ func _ready():
 	displayFpsButton.pressed = Save.game_data.display_fps
 	#instancing Fps slider 
 	maxFpsSlider.value = Save.game_data.max_fps
+	#instancing bloom
+	bloomButton.pressed = Save.game_data.bloom_on
 	#instancing brightness
 	brightnessSlider.value = Save.game_data.brightness
-	#instancing Master Volume
+	#instancing Volume sliders
 	masterVolSlider.value = Save.game_data.master_vol
+	musicVolSlider.value = Save.game_data.music_vol
+	sfxVolSlider.value = Save.game_data.sfx_vol
 	#instancing Mouse Sens
 	mouseSlider.value = Save.game_data.mouse_sens
 	
@@ -97,6 +107,18 @@ func _on_DisplayFpsButton_toggled(button_pressed):
 func _on_MaxFpsSlider_value_changed(value):
 	GlobalSettings.set_max_fps(value)
 	maxFpsVal.text = str(value) if value < maxFpsSlider.max_value else "Max"
+	
+"""
+/*
+* @pre called when the bloom button is pressed
+* @post calls toggle_bloom function in globalSettings.gd
+* @param button_pressed -> boolean
+
+* @return None
+*/
+"""
+func _on_BloomButton_toggled(button_pressed):
+	GlobalSettings.toggle_bloom(button_pressed)
 
 """
 /*
@@ -109,18 +131,6 @@ func _on_MaxFpsSlider_value_changed(value):
 func _on_BrightnessSlider_value_changed(value):
 	GlobalSettings.update_brightness(value)
 
-##called when the master volume slider is moved
-#func _on_MasterVolSlider_value_changed(value):
-#	pass
-#
-##called when the music volume slider is moved
-#func _on_MusicVolSlider_value_changed(value):
-#	pass # Replace with function body.
-#
-#
-#func _on_SfxVolSlider_value_changed(value):
-#	pass # Replace with function body.
-
 """
 /*
 * @pre called when the mouse sens slider is moved
@@ -132,3 +142,36 @@ func _on_BrightnessSlider_value_changed(value):
 func _on_MouseSensSlider_value_changed(value):
 	GlobalSettings.update_mouse_sens(value)
 	mouseVal.text = str(value)
+
+"""
+/*
+* @pre called when the master volume slider is moved
+* @post calls update_volume function in globalSettings.gd with master param
+* @param button_pressed -> integer
+* @return None
+*/
+"""
+func _on_MasterVolSlider_value_changed(value):
+	GlobalSettings.update_volume(MASTER_VOLUME,value)
+
+"""
+/*
+* @pre called when the master volume slider is moved
+* @post calls update_volume function in globalSettings.gd with music param
+* @param button_pressed -> integer
+* @return None
+*/
+"""
+func _on_MusicVolSlider_value_changed(value):
+	GlobalSettings.update_volume(MUSIC_VOLUME,value)
+
+"""
+/*
+* @pre called when the master volume slider is moved
+* @post calls update_volume function in globalSettings.gd with sfx param
+* @param button_pressed -> integer
+* @return None
+*/
+"""
+func _on_SfxVolSlider_value_changed(value):
+	GlobalSettings.update_volume(SFX_VOLUME,value)

--- a/game/Scenes/SettingsMenu/settingsMenu.tscn
+++ b/game/Scenes/SettingsMenu/settingsMenu.tscn
@@ -111,6 +111,19 @@ min_value = 30.0
 max_value = 500.0
 value = 500.0
 
+[node name="BloomLabel" type="Label" parent="SettingsTabs/Video/MarginContainer/videoSettings"]
+margin_top = 189.0
+margin_right = 87.0
+margin_bottom = 203.0
+text = "Bloom"
+
+[node name="BloomButton" type="CheckButton" parent="SettingsTabs/Video/MarginContainer/videoSettings"]
+margin_left = 1146.0
+margin_top = 176.0
+margin_right = 1222.0
+margin_bottom = 216.0
+size_flags_horizontal = 10
+
 [node name="BrightnessLabel" type="Label" parent="SettingsTabs/Video/MarginContainer/videoSettings"]
 margin_top = 231.0
 margin_right = 87.0
@@ -131,6 +144,7 @@ margin_bottom = 31.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 10
 size_flags_vertical = 1
+min_value = 0.2
 max_value = 2.0
 step = 0.1
 value = 1.0
@@ -178,7 +192,7 @@ margin_bottom = 31.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 10
 size_flags_vertical = 1
-min_value = -50.0
+min_value = -20.0
 max_value = 0.0
 value = -10.0
 
@@ -201,7 +215,7 @@ margin_bottom = 16.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 10
 size_flags_vertical = 1
-min_value = -50.0
+min_value = -20.0
 max_value = 0.0
 value = -10.0
 
@@ -225,7 +239,7 @@ margin_bottom = 31.0
 rect_min_size = Vector2( 400, 0 )
 size_flags_horizontal = 10
 size_flags_vertical = 1
-min_value = -50.0
+min_value = -20.0
 max_value = 0.0
 value = -10.0
 
@@ -289,8 +303,9 @@ value = 0.1
 [connection signal="toggled" from="SettingsTabs/Video/MarginContainer/videoSettings/VsyncButton" to="." method="_on_VsyncButton_toggled"]
 [connection signal="toggled" from="SettingsTabs/Video/MarginContainer/videoSettings/DisplayFpsButton" to="." method="_on_DisplayFpsButton_toggled"]
 [connection signal="value_changed" from="SettingsTabs/Video/MarginContainer/videoSettings/FpsSlider/MaxFpsSlider" to="." method="_on_MaxFpsSlider_value_changed"]
+[connection signal="toggled" from="SettingsTabs/Video/MarginContainer/videoSettings/BloomButton" to="." method="_on_BloomButton_toggled"]
 [connection signal="value_changed" from="SettingsTabs/Video/MarginContainer/videoSettings/Brightness/BrightnessSlider" to="." method="_on_BrightnessSlider_value_changed"]
 [connection signal="value_changed" from="SettingsTabs/Audio/MarginContainer/audioSettings/MasterVol/MasterVolSlider" to="." method="_on_MasterVolSlider_value_changed"]
-[connection signal="value_changed" from="SettingsTabs/Audio/MarginContainer/audioSettings/MusicVal/MusicVolSlider" to="." method="_on_MusicValSlider_value_changed"]
+[connection signal="value_changed" from="SettingsTabs/Audio/MarginContainer/audioSettings/MusicVal/MusicVolSlider" to="." method="_on_MusicVolSlider_value_changed"]
 [connection signal="value_changed" from="SettingsTabs/Audio/MarginContainer/audioSettings/SfxVol/SfxVolSlider" to="." method="_on_SfxVolSlider_value_changed"]
 [connection signal="value_changed" from="SettingsTabs/Gameplay/GameplaySettings/audioSettings/MouseSense/MouseSensSlider" to="." method="_on_MouseSensSlider_value_changed"]

--- a/game/Scenes/fpsDisplay/fpsLabel.gd
+++ b/game/Scenes/fpsDisplay/fpsLabel.gd
@@ -19,6 +19,7 @@ extends Label
 */
 """
 func _ready():
+	# warning-ignore:return_value_discarded
 	GlobalSettings.connect("fpsDisplayed", self, "_on_fps_displayed")
 
 """
@@ -29,7 +30,7 @@ func _ready():
 * @return None
 */
 """
-func _process(delta):
+func _process(_delta): # _delta means delta is not used, change to delta if not the case
 	text = "FPS: %s" % [Engine.get_frames_per_second()]
 
 """

--- a/game/Scenes/mainMenu/mainMenu.gd
+++ b/game/Scenes/mainMenu/mainMenu.gd
@@ -10,10 +10,11 @@
 
 extends Control
 
-
-# Declare member variables here. Examples:
+# Member Variables
+onready var startButton = $VBoxContainer/Start
 onready var settingsMenu = $SettingsMenu
 onready var fpsLabel = $fpsLabel
+onready var worldEnv = $WorldEnvironment
 
 
 """
@@ -25,8 +26,17 @@ onready var fpsLabel = $fpsLabel
 */
 """
 func _ready():
-	$VBoxContainer/Start.grab_focus()
+	#Grab focus on start button so keys can be used to navigate buttons
+	startButton.grab_focus()
+	#Call function to use user saved fps
 	fpsLabel._on_fps_displayed(Save.game_data.display_fps)
+	#Call functions to use user saved brightness and bloom values
+	worldEnv._on_brightness_toggled(Save.game_data.brightness)
+	worldEnv._on_bloom_toggled(Save.game_data.bloom_on)
+	#Call functions to sync audio settings with user save
+	settingsMenu._on_MasterVolSlider_value_changed(Save.game_data.master_vol)
+	settingsMenu._on_MusicVolSlider_value_changed(Save.game_data.music_vol)
+	settingsMenu._on_SfxVolSlider_value_changed(Save.game_data.sfx_vol)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -56,7 +66,7 @@ func _on_Start_pressed():
 */
 """
 func _on_Options_pressed():
-	settingsMenu.popup_centered()
+	settingsMenu.popup_centered_ratio()
 
 """
 /*

--- a/game/Scenes/mainMenu/mainMenu.tscn
+++ b/game/Scenes/mainMenu/mainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://Scenes/mainMenu/mainMenu.gd" type="Script" id=1]
 [ext_resource path="res://Assets/mainMenuAssets/LTYPEB.TTF" type="DynamicFontData" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://Assets/fire5.png" type="Texture" id=6]
 [ext_resource path="res://Scenes/fpsDisplay/fpsLabel.tscn" type="PackedScene" id=7]
 [ext_resource path="res://Assets/ARIALBD.TTF" type="DynamicFontData" id=8]
+[ext_resource path="res://Scenes/worldEnvironment/worldEnv.tscn" type="PackedScene" id=9]
 
 [sub_resource type="DynamicFont" id=1]
 size = 38
@@ -54,6 +55,8 @@ anchor_bottom = 1.0
 margin_right = 50.0
 margin_bottom = 50.0
 script = ExtResource( 1 )
+
+[node name="WorldEnvironment" parent="." instance=ExtResource( 9 )]
 
 [node name="TextureRect" type="TextureRect" parent="."]
 anchor_right = 1.0

--- a/game/Scenes/sceneTrans/SceneTrans.gd
+++ b/game/Scenes/sceneTrans/SceneTrans.gd
@@ -19,6 +19,7 @@ extends CanvasLayer
 func change_scene(target: String) -> void:
 	$AnimationPlayer.play("DISSOLVE")
 	yield($AnimationPlayer, 'animation_finished')
+	# warning-ignore:return_value_discarded
 	get_tree().change_scene(target)
 	$AnimationPlayer.play_backwards("DISSOLVE")
 	

--- a/game/Scenes/worldEnvironment/worldEnv.gd
+++ b/game/Scenes/worldEnvironment/worldEnv.gd
@@ -1,0 +1,46 @@
+"""
+* Programmer Name - Ben Moeller
+* Description - File for controlling the wolrd environment (aka brightness and bloom of scene)
+* Date Created - 9/25/2022
+* Date Revisions:
+* Citations:
+	Based on tutorial from https://www.youtube.com/watch?v=cQkEPej_gRU
+"""
+
+extends WorldEnvironment
+
+"""
+/*
+* @pre called when environment is loaded
+* @post connects signals from globalSettings.gd
+* @param None
+* @return None
+*/
+"""
+func _ready():
+	# warning-ignore:return_value_discarded
+	GlobalSettings.connect("bloomToggled", self, "_on_bloom_toggled")
+	# warning-ignore:return_value_discarded
+	GlobalSettings.connect("brightnessUpdated", self, "_on_brightness_toggled")
+
+"""
+/*
+* @pre called when received bloom signal
+* @post changes glow_enabled to valule passed in
+* @param value -> boolean
+* @return None
+*/
+"""
+func _on_bloom_toggled(value):
+	environment.glow_enabled = value
+
+"""
+/*
+* @pre called when received brightness signal
+* @post changes adjust_brightness to valule passed in
+* @param value -> float (0.2 - 2.0)
+* @return None
+*/
+"""
+func _on_brightness_toggled(value):
+	environment.adjustment_brightness = value

--- a/game/Scenes/worldEnvironment/worldEnv.tscn
+++ b/game/Scenes/worldEnvironment/worldEnv.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Scenes/worldEnvironment/worldEnv.gd" type="Script" id=1]
+
+[sub_resource type="Environment" id=1]
+background_mode = 4
+glow_blend_mode = 0
+glow_hdr_threshold = 0.28
+adjustment_enabled = true
+
+[node name="WorldEnvironment" type="WorldEnvironment"]
+environment = SubResource( 1 )
+script = ExtResource( 1 )

--- a/game/StoreElements/StoreVars.tscn
+++ b/game/StoreElements/StoreVars.tscn
@@ -74,10 +74,12 @@ text = "STORE"
 [node name="Kaching" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 4 )
 volume_db = -26.277
+bus = "SFX"
 
 [node name="tavernbg" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 5 )
 volume_db = -27.092
+bus = "Music"
 
 [connection signal="pressed" from="Node2D/VBoxContainer/addMoney" to="." method="_on_addMoney_pressed"]
 [connection signal="pressed" from="Node2D/VBoxContainer/subMoney" to="." method="_on_subMoney_pressed"]

--- a/game/default_bus_layout.tres
+++ b/game/default_bus_layout.tres
@@ -1,0 +1,15 @@
+[gd_resource type="AudioBusLayout" format=2]
+
+[resource]
+bus/1/name = "Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = "Master"
+bus/2/name = "SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = "Master"

--- a/game/project.godot
+++ b/game/project.godot
@@ -31,11 +31,13 @@ Global="*res://Loader/Global.gd"
 
 window/size/width=1280
 window/size/height=720
+window/stretch/mode="viewport"
 
 [global]
 
 Auto=false
 icon=false
+viewport=false
 
 [gui]
 


### PR DESCRIPTION
- You can now change brightness of the main menu scene
- You can add bloom to scene (work in progress, need to add to specific nodes instead of whole screen)
- Master Volume, Music Volume, and SFX volume now functional
- Changed popup method of settings menu to ratio version, works a lot better with centering to screen
- Added two new audio busses to work with master volume (music and sfx, tutorial in discord)